### PR TITLE
Improvements for rm.go and set of tests for the code 

### DIFF
--- a/src/cmds/rm/rm.go
+++ b/src/cmds/rm/rm.go
@@ -2,12 +2,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-/*
-Rm removes the named files.
-
-The options are:
-*/
-
 package main
 
 import (
@@ -16,18 +10,26 @@ import (
 	"flag"
 )
 
-var recursive = flag.Bool("R", false, "Remove file hierarchies")
+var recursive = flag.Bool("R", false, "Remove file hierarchies.")
 var recursive_too = flag.Bool("r", false, "Equivalent to -R.")
+var verbose = flag.Bool("v", false, "Verbose mode.")
 
-func main() {
-	flag.Parse()
+func usage (){
+	fmt.Fprintf(os.Stderr, "usage: %s [-Rrv] file...\n", os.Args[0])
+	os.Exit(1)
+}
 
+// rm function 
+func rm(args []string, do_recursive bool, verbose bool) error {
+	
+	// recursive or no depend do_recursive value
 	var f = os.Remove
-	if *recursive || *recursive_too {
+	if do_recursive {
 		f = os.RemoveAll
 	}
 
-	for _,arg := range(os.Args[1:]) {
+	// looping for removing files and folders
+	for _,arg := range(args) {
 		if arg == "-r" || arg == "-R" {
 			continue
 		}
@@ -35,6 +37,22 @@ func main() {
 		err := f(arg)
 		if err != nil {
 			fmt.Printf("%v: %v\n", arg, err)
+			return err
+		}
+
+		if verbose {
+			fmt.Printf("Deleting: %v\n", arg)
 		}
 	}
+	return nil
+}
+
+func main() {
+	flag.Parse()
+
+	if flag.NArg() < 1 {
+		usage()
+	}
+
+	rm(os.Args[:1], *recursive || *recursive_too, *verbose)
 }

--- a/src/cmds/rm/rm.go
+++ b/src/cmds/rm/rm.go
@@ -15,11 +15,25 @@ import (
 	"os"
 )
 
+func printErr(file string, err error) {
+	if err != nil {
+		fmt.Printf("%v: %v\n", file, err)
+	}
+}
+
 func main() {
-	for _,v := range(os.Args[1:]) {
-		err := os.Remove(v)
-		if err != nil {
-			fmt.Printf("%v: %v\n", v, err)
+	start := 1
+	if len(os.Args) > 1 {
+		if os.Args[1] == "-r" || os.Args[1] == "-R" {
+			start = 2
+		}
+	}
+
+	for _,v := range(os.Args[start:]) {
+		if start == 2 && os.Args[1] == "-r" || os.Args[1] == "-R" {
+			printErr(v, os.RemoveAll(v))
+		} else {
+			printErr(v, os.Remove(v))
 		}
 	}
 }

--- a/src/cmds/rm/rm.go
+++ b/src/cmds/rm/rm.go
@@ -13,27 +13,28 @@ package main
 import (
 	"fmt"
 	"os"
+	"flag"
 )
 
-func printErr(file string, err error) {
-	if err != nil {
-		fmt.Printf("%v: %v\n", file, err)
-	}
-}
+var recursive = flag.Bool("R", false, "Remove file hierarchies")
+var recursive_too = flag.Bool("r", false, "Equivalent to -R.")
 
 func main() {
-	start := 1
-	if len(os.Args) > 1 {
-		if os.Args[1] == "-r" || os.Args[1] == "-R" {
-			start = 2
-		}
+	flag.Parse()
+
+	var f = os.Remove
+	if *recursive || *recursive_too {
+		f = os.RemoveAll
 	}
 
-	for _,v := range(os.Args[start:]) {
-		if start == 2 && os.Args[1] == "-r" || os.Args[1] == "-R" {
-			printErr(v, os.RemoveAll(v))
-		} else {
-			printErr(v, os.Remove(v))
+	for _,arg := range(os.Args[1:]) {
+		if arg == "-r" || arg == "-R" {
+			continue
+		}
+
+		err := f(arg)
+		if err != nil {
+			fmt.Printf("%v: %v\n", arg, err)
 		}
 	}
 }

--- a/src/cmds/rm/rm_test.go
+++ b/src/cmds/rm/rm_test.go
@@ -1,0 +1,91 @@
+// Copyright 2012 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+//  move (rename) files
+//  created by Manoel Vilela (manoel_vilela@engineer.com)
+
+package main
+
+import (
+    "fmt"
+    "io/ioutil"
+    "os"
+    "path"
+    "testing"
+)
+
+type makeit struct {
+    n string           // name
+    m os.FileMode      // mode
+    s string           // for symlinks or content
+}
+
+var tests = []makeit{
+    {
+        n: "hi1.txt",
+        m: 0666,
+        s: "",
+    },
+    {
+        n: "hi2.txt",
+        m: 0777,
+        s: "",
+    },
+    {
+        n: "go.txt",
+        m: 0555,
+        s: "",
+    },
+}
+
+// initial files and folders (for testing)
+func setup() (string, error) {
+    fmt.Println("Creating simulating data...\n")
+    d, err := ioutil.TempDir(os.TempDir(), "hi.dir")
+    if err != nil {
+        return "", err
+    }
+
+    tmpdir := path.Join(d, "hi.sub.dir")
+    if err := os.Mkdir(tmpdir, 0777); err != nil {
+        return "", err
+    }
+
+    for i := range tests {
+        if err := ioutil.WriteFile(path.Join(d, tests[i].n), []byte("Go is cool!"), tests[i].m); err != nil {
+            return "", err
+        }
+    }
+    
+    return d, nil
+}
+
+// withouth any flag
+func Test_rm_1(t *testing.T) {
+    d, err := setup()
+    if err != nil {
+        t.Fatal("Error on setup of the test: creating files and folders.")
+    }
+    defer os.RemoveAll(d)
+
+    fmt.Println("Deleting files and empty folders (no args) ...")
+    args1 := []string{path.Join(d, "hi1.txt"), path.Join(d, "hi2.txt"), path.Join(d, "go.txt")}
+    if err := rm(args1, false, true); err != nil { 
+        t.Error(err)
+    }
+}
+// using r flag
+func Test_rm_2(t *testing.T) {
+    d, err := setup()
+    if err != nil {
+        t.Fatal("Error on setup of the test: creating files and folders.")
+    }
+    defer os.RemoveAll(d)
+
+    fmt.Println("Deleting folders recursively (using -r flag) ...")
+    files2 := []string{"-r", d}
+    if err := rm(files2, true, true); err != nil {
+        t.Error(err)
+    }
+}


### PR DESCRIPTION
The new arguments implemented according [POSIX](http://pubs.opengroup.org/onlinepubs/9699919799/utilities/rm.html#tag_20_111):
- `-R` (recursive deleting)
- `-r` (alias for -R)

I add too verbose mode `-v` because is very common and util sometimes (but need enchacement with recursive mode).

Following POSIX, now lack:
- `i` (interactive mode)
- `f` (forced mode, ignore interactive mode)
